### PR TITLE
Improve helper function

### DIFF
--- a/ckanext/onicse_theme/helpers.py
+++ b/ckanext/onicse_theme/helpers.py
@@ -71,8 +71,10 @@ def get_date_by_id(package_id):
 def is_internal_login_enabled():
     """
     Check if internal login (SSO) is enabled in CKAN configuration.
+    Returns:
+        bool: True if internal login is explicitly enabled in CKAN config, otherwise False.
     """
-    enable_internal_login = toolkit.config.get('ckanext.saml2auth.enable_ckan_internal_login', 'False')
-    
-    # If the setting is None or not "True" return False
-    return enable_internal_login.lower() == 'true'
+    value = toolkit.config.get('ckanext.saml2auth.enable_ckan_internal_login', 'False')
+    if value is None:
+        return False
+    return str(value).strip().lower() == 'true'


### PR DESCRIPTION
Improve helper function. If toolkit.config.get(...) returns None, calling .lower() on it will raise an AttributeError, because None has no .lower() method. This way we can safely call .lower() even if the config value isn’t a string (for example, a boolean or None)